### PR TITLE
Integrate with HF

### DIFF
--- a/run_inference.py
+++ b/run_inference.py
@@ -1,4 +1,3 @@
-import torch
 from swarmformer.config import MODEL_CONFIGS, INFERENCE_BATCH_SIZE
 from swarmformer.inference import load_trained_model, evaluate_model, count_parameters, get_device
 

--- a/swarmformer/config.py
+++ b/swarmformer/config.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from typing import Dict
 
 @dataclass
 class ModelConfig:

--- a/swarmformer/inference.py
+++ b/swarmformer/inference.py
@@ -32,7 +32,7 @@ def load_trained_model(config: ModelConfig, device: str = 'cuda') -> Tuple[Swarm
     
     try :
         info = model_info(config.hf_model_id)
-        if "swarmformer" in info.tags:
+        if info.library_name == "swarmformer":
             model = SwarmFormerModel.from_pretrained(config.hf_model_id).to(device)
             model.eval()
         else : 

--- a/swarmformer/inference.py
+++ b/swarmformer/inference.py
@@ -1,12 +1,12 @@
 import torch
-import torch.nn as nn
 from torch.utils.data import DataLoader
 import time
 from tqdm import tqdm
 import numpy as np
 from sklearn.metrics import accuracy_score, precision_recall_fscore_support
 import os
-from huggingface_hub import hf_hub_download
+from huggingface_hub import hf_hub_download, model_info
+from huggingface_hub.errors import RepositoryNotFoundError
 from safetensors.torch import load_file
 from typing import Dict, Any, Tuple
 
@@ -30,30 +30,30 @@ def load_trained_model(config: ModelConfig, device: str = 'cuda') -> Tuple[Swarm
         augment=False
     )
     
-    # Initialize model with configuration
-    model = SwarmFormerModel(
-        vocab_size=test_dataset.vocab_size(),
-        d_model=config.d_model,
-        seq_len=config.seq_len,
-        cluster_size=config.cluster_size,
-        num_layers=config.num_layers,
-        T_local=config.T_local
-    ).to(device)
-    
-    # Turn off dropout for inference
-    for module in model.modules():
-        if isinstance(module, nn.Dropout):
-            module.p = 0.0
-    
-    # Download and load model weights from HuggingFace
-    try:
-        checkpoint_path = hf_hub_download(
-            repo_id=config.hf_model_id,
-            filename="model.safetensors"
-        )
-        state_dict = load_file(checkpoint_path)  # Load safetensors file
-        model.load_state_dict(state_dict, strict=False)
-    except Exception as e:
+    try :
+        info = model_info(config.hf_model_id)
+        if "swarmformer" in info.tags:
+            model = SwarmFormerModel.from_pretrained(config.hf_model_id).to(device)
+            model.eval()
+        else : 
+            # implement backward compatibility script 
+            model = SwarmFormerModel(
+                vocab_size=test_dataset.vocab_size(),
+                d_model=config.d_model,
+                seq_len=config.seq_len,
+                cluster_size=config.cluster_size,
+                num_layers=config.num_layers,
+                T_local=config.T_local
+            ).to(device)
+            checkpoint_path = hf_hub_download(
+                repo_id=config.hf_model_id,
+                filename="model.safetensors"
+            )
+            state_dict = load_file(checkpoint_path)  # Load safetensors file
+            model.load_state_dict(state_dict, strict=False)
+            model.eval()
+
+    except RepositoryNotFoundError as e:
         raise RuntimeError(f"Failed to load model from HuggingFace: {str(e)}")
     
     return model, test_dataset

--- a/swarmformer/model.py
+++ b/swarmformer/model.py
@@ -172,9 +172,8 @@ class SwarmFormerLayer(nn.Module):
 
 class SwarmFormerModel(nn.Module,
                     PyTorchModelHubMixin,
-                    library_name="SwarmFormer",
+                    library_name="swarmformer",
                     repo_url="https://github.com/takara-ai/SwarmFormer",
-                    tags = ["swarmformer"]
                     ):
     def __init__(self, vocab_size=10, d_model=16, seq_len=16, cluster_size=4, num_layers=2, T_local=2):
         super().__init__()

--- a/swarmformer/model.py
+++ b/swarmformer/model.py
@@ -1,5 +1,6 @@
 import torch
 import torch.nn as nn
+from huggingface_hub import PyTorchModelHubMixin
 
 class TokenEmbedding(nn.Module):
     def __init__(self, vocab_size=10, d_model=16):
@@ -169,7 +170,12 @@ class SwarmFormerLayer(nn.Module):
 
         return x_out
 
-class SwarmFormerModel(nn.Module):
+class SwarmFormerModel(nn.Module,
+                    PyTorchModelHubMixin,
+                    library_name="SwarmFormer",
+                    repo_url="https://github.com/takara-ai/SwarmFormer",
+                    tags = ["swarmformer"]
+                    ):
     def __init__(self, vocab_size=10, d_model=16, seq_len=16, cluster_size=4, num_layers=2, T_local=2):
         super().__init__()
         self.embedding = TokenEmbedding(vocab_size, d_model)


### PR DESCRIPTION
This pr will integrate swarmformer with HF by adding the following 3 methods to the model 
* `save_pretrained`
* `from_pretrained`
* `push_to_hub` 

I made a notebook on how to migrate your weights for this specific model which you can find here: https://colab.research.google.com/drive/1gYsArM7YO1MwS663tmfuuW-651YvI-yg?usp=sharing

> [!IMPORTANT]  
> It is essential that you load your current checkpoint first then use `model.push_to_hub` to push your model along with the necessary metadata to the hub as mentioned in the notebook.

By using PyTorchModelHubMixin you get :
* Automatic model card generation: the metadata in the card allows you to filter your [searches](https://huggingface.co/models?other=swarmformer) easily to check how many swarmformer models exist on the Hub.
 * Recommended: after this pr is merged we can open a pull request [on this file](https://github.com/huggingface/huggingface.js/blob/main/packages/tasks/src/model-libraries.ts) to make the "swarmformer" library official on the Hub meaning better discoverability + code snippets 
 
Do not hesitate if you have any reviews on the pr or any questions.

Best regards,
Hafedh Hichri